### PR TITLE
 OCE-38: Add log rotation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,6 @@
             <version>${kafka.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
             <groupId>args4j</groupId>
             <artifactId>args4j</artifactId>
             <version>2.33</version>
@@ -139,6 +134,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
         </dependency>
 
         <!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <jackson.version>2.9.6</jackson.version>
         <kafka.version>2.1.0</kafka.version>
         <RUNAS>opennms-kem</RUNAS>
-        <LOGFILE>/var/log/${project.name}.log</LOGFILE>
+        <LOGFILE>/var/log/${project.name}-output.log</LOGFILE>
     </properties>
 
     <dependencies>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,6 @@
             <fileNamePattern>mirror.%i.log.zip</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>4</maxIndex>
-            <totalSizeCap>500MB</totalSizeCap>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <maxFileSize>100MB</maxFileSize>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,9 +2,9 @@
 <configuration>
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>mirror.log</file>
+        <file>/var/log/kem.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>mirror.%i.log.zip</fileNamePattern>
+            <fileNamePattern>/var/log/kem.%i.log.zip</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>4</maxIndex>
         </rollingPolicy>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>mirror.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>mirror.%i.log.zip</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>4</maxIndex>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>
+


### PR DESCRIPTION
This PR sends logger output to 'mirror.log' and provides log rotation when the log file gets to 100MB and keep the latest 4.

* JIRA: https://issues.opennms.org/browse/OCE-38
