### PR TITLE
OCE-38: Move logs int /var/log/kem to addr permission issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <jackson.version>2.9.6</jackson.version>
         <kafka.version>2.1.0</kafka.version>
         <RUNAS>opennms-kem</RUNAS>
-        <LOGFILE>/var/log/${project.name}-output.log</LOGFILE>
     </properties>
 
     <dependencies>

--- a/src/main/filtered-resources/etc/kafka-event-mirrorer.init
+++ b/src/main/filtered-resources/etc/kafka-event-mirrorer.init
@@ -25,9 +25,10 @@ SYSCONFDIR="@SYSCONFDIR@"
 STOP_RETRIES=3
 STOP_WAIT=10
 
-RUNAS="root"
+RUNAS="@RUNAS@"
 PIDFILE="$APP_PREFIX/run/$NAME.pid"
-LOGFILE="@LOGFILE@"
+LOGDIR="/var/log/kem/"
+LOGFILE="$LOGDIR/kem.log"
 
 if [ -f /lib/lsb/init-functions ]; then
 	# shellcheck disable=SC1090,SC1091
@@ -77,6 +78,16 @@ run_java() {
 	START_STOP_DAEMON="$(command -v start-stop-daemon)"
 	RUNUSER="$(runuser -u "$RUNAS" true 2>/dev/null && command -v runuser)"
 	JAVA="$JAVA_HOME/bin/java"
+	if [ ! -d "$LOGDIR" ]; then
+	        mkdir $LOGDIR
+	        chmod 6755 $LOGDIR
+	        chown $RUNAS:$RUNAS $LOGDIR
+	fi
+	if [ ! -f "$LOGFILE" ]; then
+	        touch $LOGFILE
+	        chmod 6755 $LOGFILE
+	        chown $RUNAS:$RUNAS $LOGFILE
+	fi
 	if [ "$(id -n -u)" "!=" "$RUNAS" ]; then
 		if [ -n "$START_STOP_DAEMON" ]; then
 			# shellcheck disable=SC2086

--- a/src/main/filtered-resources/etc/kafka-event-mirrorer.init
+++ b/src/main/filtered-resources/etc/kafka-event-mirrorer.init
@@ -28,7 +28,7 @@ STOP_WAIT=10
 RUNAS="@RUNAS@"
 PIDFILE="$APP_PREFIX/run/$NAME.pid"
 LOGDIR="/var/log/kem/"
-LOGFILE="$LOGDIR/kem.log"
+LOGFILE="$LOGDIR/kem-output.log"
 
 if [ -f /lib/lsb/init-functions ]; then
 	# shellcheck disable=SC1090,SC1091

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,9 +2,9 @@
 <configuration>
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/kem.log</file>
+        <file>/var/log/kem/kem.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/var/log/kem.%i.log.zip</fileNamePattern>
+            <fileNamePattern>/var/log/kem/kem.%i.log.zip</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>4</maxIndex>
         </rollingPolicy>


### PR DESCRIPTION
This PR moves the log fir from /var/log to /var/log/kem in order to work around permission issues.
LOGFILE param is removed from the pom as the directory is encoded in the init script and this value is now ignored.

